### PR TITLE
Bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.1-RC13]
+
+- Fixed the data saving format in Aerospike
+- Fixed the rollOverAndUpdate
+
 ## [0.0.1-RC12]
 
 - Introduced orgId and tenantId to configKey

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 - Fixed the data saving format in Aerospike
 - Fixed the rollOverAndUpdate
+- Identified a weird client bug in Aerospike. If there are no records OR only one record Predicate.or/and don't work. They need special handling. And there's barely any documentation on the same 
 
 ## [0.0.1-RC12]
 

--- a/concierge-aerospike-dw/pom.xml
+++ b/concierge-aerospike-dw/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>0.0.1-RC12</version>
+        <version>0.0.1-RC13</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-aerospike/pom.xml
+++ b/concierge-aerospike/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>0.0.1-RC12</version>
+        <version>0.0.1-RC13</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-aerospike/src/main/java/com/grookage/concierge/aerospike/client/AerospikeClientUtils.java
+++ b/concierge-aerospike/src/main/java/com/grookage/concierge/aerospike/client/AerospikeClientUtils.java
@@ -14,7 +14,6 @@ import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStreamReader;
-import java.util.Base64;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.zip.GZIPInputStream;
@@ -75,6 +74,7 @@ public class AerospikeClientUtils {
         final var writePolicy = getWritePolicy(config);
         final var scanPolicy = getScanPolicy(config);
         final var batchPolicy = getBatchPolicy(config);
+        final var queryPolicy = getQueryPolicy(config);
 
         clientPolicy.user = config.getUsername();
         clientPolicy.password = config.getPassword();
@@ -83,6 +83,7 @@ public class AerospikeClientUtils {
         clientPolicy.writePolicyDefault = writePolicy;
         clientPolicy.scanPolicyDefault = scanPolicy;
         clientPolicy.batchPolicyDefault = batchPolicy;
+        clientPolicy.queryPolicyDefault = queryPolicy;
         clientPolicy.failIfNotConnected = true;
         clientPolicy.threadPool = Executors.newFixedThreadPool(config.getThreadPoolSize());
 
@@ -93,8 +94,18 @@ public class AerospikeClientUtils {
 
     }
 
+    public QueryPolicy getQueryPolicy(final AerospikeConfig config) {
+        final var queryPolicy = new QueryPolicy();
+        queryPolicy.readModeAP = ReadModeAP.ONE;
+        queryPolicy.replica = Replica.MASTER_PROLES;
+        queryPolicy.maxConcurrentNodes = config.getBatchMaxConcurrentNodes();
+        return queryPolicy;
+    }
+
     public BatchPolicy getBatchPolicy(final AerospikeConfig config) {
         final var batchPolicy = new BatchPolicy();
+        batchPolicy.readModeAP = ReadModeAP.ONE;
+        batchPolicy.replica = Replica.MASTER_PROLES;
         batchPolicy.maxConcurrentThreads = config.getBatchMaxConcurrentNodes();
         batchPolicy.allowInline = true;
         return batchPolicy;

--- a/concierge-aerospike/src/main/java/com/grookage/concierge/aerospike/client/AerospikeClientUtils.java
+++ b/concierge-aerospike/src/main/java/com/grookage/concierge/aerospike/client/AerospikeClientUtils.java
@@ -132,19 +132,19 @@ public class AerospikeClientUtils {
     }
 
     @SneakyThrows
-    public static String compress(final byte[] bytes) {
+    public static byte[] compress(final byte[] bytes) {
         final var bos = new ByteArrayOutputStream();
         final var gzip = new GZIPOutputStream(bos);
         gzip.write(bytes);
         gzip.close();
-        return Base64.getEncoder().encodeToString(bos.toByteArray());
+        return bos.toByteArray();
     }
 
     @SneakyThrows
-    public static String retrieve(final String value) {
+    public static String retrieve(final byte[] value) {
         final var gis = new GZIPInputStream(
                 new ByteArrayInputStream(
-                        Base64.getDecoder().decode(value)
+                        value
                 ));
         final var bf = new BufferedReader(new InputStreamReader(gis));
         final var stringBuilder = new StringBuilder();

--- a/concierge-aerospike/src/main/java/com/grookage/concierge/aerospike/client/AerospikeConfig.java
+++ b/concierge-aerospike/src/main/java/com/grookage/concierge/aerospike/client/AerospikeConfig.java
@@ -21,6 +21,7 @@ public class AerospikeConfig {
     private String namespace;
     private String username;
     private String password;
+    private boolean txnEnabled = false;
     private boolean tlsEnabled = false;
 
     @Builder.Default

--- a/concierge-aerospike/src/main/java/com/grookage/concierge/aerospike/repository/AerospikeRepository.java
+++ b/concierge-aerospike/src/main/java/com/grookage/concierge/aerospike/repository/AerospikeRepository.java
@@ -85,7 +85,7 @@ public class AerospikeRepository implements ConciergeRepository {
                 .namespaces(Set.of(configDetails.getConfigKey().getNamespace()))
                 .tenants(Set.of(configDetails.getConfigKey().getTenantId()))
                 .configNames(Set.of(configDetails.getConfigKey().getConfigName()))
-                .configStates(Set.of(ConfigState.APPROVED))
+                .configStates(Set.of(ConfigState.ACTIVATED))
                 .build();
         final var newRecords = aerospikeManager.getRecords(searchRequest)
                 .stream().peek(each -> each.setConfigState(ConfigState.ROLLED)).collect(Collectors.toList());

--- a/concierge-aerospike/src/main/java/com/grookage/concierge/aerospike/repository/AerospikeRepository.java
+++ b/concierge-aerospike/src/main/java/com/grookage/concierge/aerospike/repository/AerospikeRepository.java
@@ -85,7 +85,7 @@ public class AerospikeRepository implements ConciergeRepository {
                 .namespaces(Set.of(configDetails.getConfigKey().getNamespace()))
                 .tenants(Set.of(configDetails.getConfigKey().getTenantId()))
                 .configNames(Set.of(configDetails.getConfigKey().getConfigName()))
-                .configStates(Set.of(ConfigState.ACTIVATED))
+                .configStates(Set.of(ConfigState.APPROVED))
                 .build();
         final var newRecords = aerospikeManager.getRecords(searchRequest)
                 .stream().peek(each -> each.setConfigState(ConfigState.ROLLED)).collect(Collectors.toList());

--- a/concierge-aerospike/src/main/java/com/grookage/concierge/aerospike/repository/AerospikeRepository.java
+++ b/concierge-aerospike/src/main/java/com/grookage/concierge/aerospike/repository/AerospikeRepository.java
@@ -46,12 +46,12 @@ public class AerospikeRepository implements ConciergeRepository {
 
     @Override
     public void create(ConfigDetails configDetails) {
-        aerospikeManager.create(toStorageRecord(configDetails));
+        aerospikeManager.save(toStorageRecord(configDetails));
     }
 
     @Override
     public void update(ConfigDetails configDetails) {
-        aerospikeManager.update(toStorageRecord(configDetails));
+        aerospikeManager.save(toStorageRecord(configDetails));
     }
 
     @Override

--- a/concierge-aerospike/src/main/java/com/grookage/concierge/aerospike/storage/AerospikeStorageConstants.java
+++ b/concierge-aerospike/src/main/java/com/grookage/concierge/aerospike/storage/AerospikeStorageConstants.java
@@ -5,8 +5,8 @@ import lombok.experimental.UtilityClass;
 @UtilityClass
 public class AerospikeStorageConstants {
 
-    public static final String DEFAULT_BIN = "default";
     public static final String CONFIG_SET = "configs";
+    public static final String DEFAULT_BIN = "default";
     public static final String NAMESPACE_BIN = "namespace";
     public static final String CONFIG_BIN = "configName";
     public static final String CONFIG_STATE_BIN = "configState";

--- a/concierge-bom/pom.xml
+++ b/concierge-bom/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge</artifactId>
-        <version>0.0.1-RC12</version>
+        <version>0.0.1-RC13</version>
     </parent>
 
     <artifactId>concierge-bom</artifactId>

--- a/concierge-client-dw/pom.xml
+++ b/concierge-client-dw/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>0.0.1-RC12</version>
+        <version>0.0.1-RC13</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-client/pom.xml
+++ b/concierge-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>0.0.1-RC12</version>
+        <version>0.0.1-RC13</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-core/pom.xml
+++ b/concierge-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>0.0.1-RC12</version>
+        <version>0.0.1-RC13</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-core/src/main/java/com/grookage/concierge/core/cache/CacheConfig.java
+++ b/concierge-core/src/main/java/com/grookage/concierge/core/cache/CacheConfig.java
@@ -14,5 +14,6 @@ import lombok.NoArgsConstructor;
 public class CacheConfig {
 
     private boolean enabled;
-    private int refreshCacheSeconds;
+    @Builder.Default
+    private int refreshCacheSeconds = 10;
 }

--- a/concierge-core/src/main/java/com/grookage/concierge/core/engine/ConciergeHub.java
+++ b/concierge-core/src/main/java/com/grookage/concierge/core/engine/ConciergeHub.java
@@ -51,7 +51,7 @@ public class ConciergeHub {
     }
 
     public ConciergeHub withConfigVersionManager(ConfigVersionManager manager) {
-        Preconditions.checkNotNull(configVersionManager, "Config Version Manager can't be null");
+        Preconditions.checkNotNull(manager, "Config Version Manager can't be null");
         this.configVersionManager = manager;
         return this;
     }

--- a/concierge-dw/pom.xml
+++ b/concierge-dw/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>0.0.1-RC12</version>
+        <version>0.0.1-RC13</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-dw/src/main/java/com/grookage/conceirge/dwserver/ConciergeBundle.java
+++ b/concierge-dw/src/main/java/com/grookage/conceirge/dwserver/ConciergeBundle.java
@@ -67,7 +67,6 @@ public abstract class ConciergeBundle<T extends Configuration, U extends ConfigU
 
     protected ConfigVersionManager getConfigVersionManageR(T configuration) {
         return new DefaultConfigVersionManager();
-
     }
 
     protected abstract Supplier<ConfigDataValidator> getConfigDataValidator(T configuration);

--- a/concierge-dw/src/main/java/com/grookage/conceirge/dwserver/resources/ConfigResource.java
+++ b/concierge-dw/src/main/java/com/grookage/conceirge/dwserver/resources/ConfigResource.java
@@ -78,7 +78,7 @@ public class ConfigResource {
     @Timed
     @ExceptionMetered
     @Path("/{referenceId}/summary")
-    public List<ConfigurationResponse> getSchemaDetails(
+    public List<ConfigurationResponse> getConfigDetails(
             @QueryParam("ignoreCache") boolean ignoreCache,
             @PathParam("referenceId") @NotEmpty final String referenceId
     ) {
@@ -90,7 +90,7 @@ public class ConfigResource {
     @Timed
     @ExceptionMetered
     @Path("/summary")
-    public List<ConfigurationResponse> getSchemaDetails(
+    public List<ConfigurationResponse> getConfigDetails(
             @QueryParam("ignoreCache") boolean ignoreCache, @Valid final ConfigKey configKey
     ) {
         final var config = configService.getConfig(toRequestContext(ignoreCache), configKey).orElse(null);

--- a/concierge-elastic-dw/pom.xml
+++ b/concierge-elastic-dw/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>0.0.1-RC12</version>
+        <version>0.0.1-RC13</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-elastic/pom.xml
+++ b/concierge-elastic/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>0.0.1-RC12</version>
+        <version>0.0.1-RC13</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-elastic/src/main/java/com/grookage/concierge/elastic/repository/ElasticRepository.java
+++ b/concierge-elastic/src/main/java/com/grookage/concierge/elastic/repository/ElasticRepository.java
@@ -208,7 +208,7 @@ public class ElasticRepository implements ConciergeRepository {
     public void rollOverAndUpdate(ConfigDetails configDetails) {
         final var namespaceQuery = TermQuery.of(p -> p.field(NAMESPACE).value(configDetails.getConfigKey().getNamespace()))._toQuery();
         final var configQuery = TermQuery.of(p -> p.field(CONFIG_NAME).value(configDetails.getConfigKey().getConfigName()))._toQuery();
-        final var stateQuery = TermQuery.of(p -> p.field(CONFIG_STATE).value(ConfigState.APPROVED.name()))._toQuery();
+        final var stateQuery = TermQuery.of(p -> p.field(CONFIG_STATE).value(ConfigState.ACTIVATED.name()))._toQuery();
         final var orgQuery = TermQuery.of(p -> p.field(ORG).value(configDetails.getConfigKey().getOrgId()))._toQuery();
         final var tenantQuery = TermQuery.of(p -> p.field(TENANT).value(configDetails.getConfigKey().getTenantId()))._toQuery();
         final var searchQuery = BoolQuery.of(q -> q.must(List.of(orgQuery, namespaceQuery, tenantQuery,

--- a/concierge-elastic/src/main/java/com/grookage/concierge/elastic/repository/ElasticRepository.java
+++ b/concierge-elastic/src/main/java/com/grookage/concierge/elastic/repository/ElasticRepository.java
@@ -208,7 +208,7 @@ public class ElasticRepository implements ConciergeRepository {
     public void rollOverAndUpdate(ConfigDetails configDetails) {
         final var namespaceQuery = TermQuery.of(p -> p.field(NAMESPACE).value(configDetails.getConfigKey().getNamespace()))._toQuery();
         final var configQuery = TermQuery.of(p -> p.field(CONFIG_NAME).value(configDetails.getConfigKey().getConfigName()))._toQuery();
-        final var stateQuery = TermQuery.of(p -> p.field(CONFIG_STATE).value(ConfigState.ACTIVATED.name()))._toQuery();
+        final var stateQuery = TermQuery.of(p -> p.field(CONFIG_STATE).value(ConfigState.APPROVED.name()))._toQuery();
         final var orgQuery = TermQuery.of(p -> p.field(ORG).value(configDetails.getConfigKey().getOrgId()))._toQuery();
         final var tenantQuery = TermQuery.of(p -> p.field(TENANT).value(configDetails.getConfigKey().getTenantId()))._toQuery();
         final var searchQuery = BoolQuery.of(q -> q.must(List.of(orgQuery, namespaceQuery, tenantQuery,

--- a/concierge-models/pom.xml
+++ b/concierge-models/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>0.0.1-RC12</version>
+        <version>0.0.1-RC13</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-parent/pom.xml
+++ b/concierge-parent/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-bom</artifactId>
-        <version>0.0.1-RC12</version>
+        <version>0.0.1-RC13</version>
         <relativePath>../concierge-bom</relativePath>
     </parent>
 

--- a/concierge-repository/pom.xml
+++ b/concierge-repository/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>0.0.1-RC12</version>
+        <version>0.0.1-RC13</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-server-example/config/concierge.yml
+++ b/concierge-server-example/config/concierge.yml
@@ -18,7 +18,7 @@ server:
 logging:
   level: INFO
   loggers:
-    com.phonepe.concierge: DEBUG
+    com.grookage.concierge: DEBUG
   appenders:
     - type: console
       threshold: INFO

--- a/concierge-server-example/config/concierge.yml
+++ b/concierge-server-example/config/concierge.yml
@@ -1,0 +1,40 @@
+name: concierge
+
+server:
+  maxThreads: 128
+  minThreads: 128
+  applicationConnectors:
+    - type: http
+      port: 18080
+  adminConnectors:
+    - type: http
+      port: 18081
+  applicationContextPath: /
+  requestLog:
+    appenders:
+      - type: console
+        timeZone: IST
+
+logging:
+  level: INFO
+  loggers:
+    com.phonepe.concierge: DEBUG
+  appenders:
+    - type: console
+      threshold: INFO
+      timeZone: IST
+      logFormat: "%(%-5level) [%date] [%thread] [%logger{0}]: %message%n"
+
+aerospikeConfig:
+  namespace: test
+  hosts:
+    - host: localhost
+      port: 3000
+  username:
+  password:
+  maxConnectionsPerNode: 10
+  timeout: 1000
+  retries: 3
+  sleepBetweenRetries: 5
+  maxSocketIdle: 4140
+  threadPoolSize: 512

--- a/concierge-server-example/pom.xml
+++ b/concierge-server-example/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>0.0.1-RC12</version>
+        <version>0.0.1-RC13</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-server-example/pom.xml
+++ b/concierge-server-example/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.grookage.concierge</groupId>
+        <artifactId>concierge-parent</artifactId>
+        <version>0.0.1-RC12</version>
+        <relativePath>../concierge-parent</relativePath>
+    </parent>
+
+    <artifactId>concierge-server-example</artifactId>
+
+    <dependencies>
+        <dependency>
+            <artifactId>dropwizard-core</artifactId>
+            <groupId>io.dropwizard</groupId>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/io.dropwizard/dropwizard-validation -->
+        <dependency>
+            <artifactId>dropwizard-validation</artifactId>
+            <groupId>io.dropwizard</groupId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.grookage.concierge</groupId>
+            <artifactId>concierge-aerospike-dw</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.grookage.concierge</groupId>
+            <artifactId>concierge-models</artifactId>
+        </dependency>
+
+    </dependencies>
+
+
+</project>

--- a/concierge-server-example/src/main/java/com/grookage/concierge/server/App.java
+++ b/concierge-server-example/src/main/java/com/grookage/concierge/server/App.java
@@ -1,0 +1,107 @@
+package com.grookage.concierge.server;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+import com.grookage.conceirge.dwserver.permissions.PermissionValidator;
+import com.grookage.conceirge.dwserver.resolvers.ConfigUpdaterResolver;
+import com.grookage.concierge.aerospike.client.AerospikeConfig;
+import com.grookage.concierge.aerospikedw.ConciergeAerospikeBundle;
+import com.grookage.concierge.core.cache.CacheConfig;
+import com.grookage.concierge.core.engine.validator.ConfigDataValidator;
+import com.grookage.concierge.models.config.ConfigKey;
+import com.grookage.concierge.models.ingestion.ConfigurationRequest;
+import com.grookage.concierge.models.ingestion.UpdateConfigRequest;
+import io.dropwizard.Application;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.ws.rs.core.HttpHeaders;
+import java.util.function.Supplier;
+
+@Slf4j
+public class App extends Application<AppConfiguration> {
+
+    public static void main(final String[] args) throws Exception {
+        new App().run(args);
+    }
+
+    @Override
+    public void initialize(final Bootstrap<AppConfiguration> bootstrap) {
+        final var bundle = new ConciergeAerospikeBundle<AppConfiguration, ConciergeConfigUpdater>() {
+            @Override
+            protected Supplier<ConfigUpdaterResolver<ConciergeConfigUpdater>> userResolver(AppConfiguration configuration) {
+                return () -> httpHeaders -> new ConciergeConfigUpdater();
+            }
+
+            @Override
+            protected CacheConfig getCacheConfig(AppConfiguration configuration) {
+                return CacheConfig.builder()
+                        .enabled(true)
+                        .refreshCacheSeconds(10)
+                        .build();
+            }
+
+            @Override
+            protected Supplier<PermissionValidator<ConciergeConfigUpdater>> getPermissionResolver(AppConfiguration configuration) {
+                return () -> new PermissionValidator<>() {
+                    @Override
+                    public void authorize(HttpHeaders headers, ConciergeConfigUpdater schemaUpdater, ConfigurationRequest configurationRequest) {
+                        //NOOP
+                    }
+
+                    @Override
+                    public void authorize(HttpHeaders headers, ConciergeConfigUpdater schemaUpdater, UpdateConfigRequest configRequest) {
+                        //NOOP
+                    }
+
+                    @Override
+                    public void authorizeApproval(HttpHeaders headers, ConciergeConfigUpdater schemaUpdater, ConfigKey schemaKey) {
+                        //NOOP
+                    }
+
+                    @Override
+                    public void authorizeRejection(HttpHeaders headers, ConciergeConfigUpdater schemaUpdater, ConfigKey schemaKey) {
+                        //NOOP
+                    }
+
+                    @Override
+                    public void authorizeActivation(HttpHeaders headers, ConciergeConfigUpdater schemaUpdater, ConfigKey schemaKey) {
+                        //NOOP
+                    }
+                };
+            }
+
+            @Override
+            protected Supplier<ConfigDataValidator> getConfigDataValidator(AppConfiguration configuration) {
+                return () -> (configKey, configData) -> {
+                };
+            }
+
+            @Override
+            protected AerospikeConfig getAerospikeConfig(AppConfiguration configuration) {
+                return configuration.getAerospikeConfig();
+            }
+        };
+        bootstrap.addBundle(bundle);
+    }
+
+    @Override
+    public void run(AppConfiguration appConfiguration, Environment environment) {
+        environment.getObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        environment.getObjectMapper().registerModule(new GuavaModule())
+                .registerModule(new Jdk8Module())
+                .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+                .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
+                .enable(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES)
+                .registerModule(new ParameterNamesModule(JsonCreator.Mode.PROPERTIES));
+    }
+
+}

--- a/concierge-server-example/src/main/java/com/grookage/concierge/server/App.java
+++ b/concierge-server-example/src/main/java/com/grookage/concierge/server/App.java
@@ -45,7 +45,7 @@ public class App extends Application<AppConfiguration> {
             protected CacheConfig getCacheConfig(AppConfiguration configuration) {
                 return CacheConfig.builder()
                         .enabled(true)
-                        .refreshCacheSeconds(10)
+                        .refreshCacheSeconds(600)
                         .build();
             }
 

--- a/concierge-server-example/src/main/java/com/grookage/concierge/server/AppConfiguration.java
+++ b/concierge-server-example/src/main/java/com/grookage/concierge/server/AppConfiguration.java
@@ -1,0 +1,25 @@
+package com.grookage.concierge.server;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.grookage.concierge.aerospike.client.AerospikeConfig;
+import io.dropwizard.Configuration;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+
+@Getter
+@Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
+@EqualsAndHashCode(callSuper = true)
+public class AppConfiguration extends Configuration {
+
+    @NotEmpty
+    @NotNull
+    private String name;
+
+    @NotNull
+    private AerospikeConfig aerospikeConfig;
+}

--- a/concierge-server-example/src/main/java/com/grookage/concierge/server/ConciergeConfigUpdater.java
+++ b/concierge-server-example/src/main/java/com/grookage/concierge/server/ConciergeConfigUpdater.java
@@ -1,0 +1,20 @@
+package com.grookage.concierge.server;
+
+import com.grookage.concierge.models.ConfigUpdater;
+
+public class ConciergeConfigUpdater implements ConfigUpdater {
+    @Override
+    public String name() {
+        return "Concierge";
+    }
+
+    @Override
+    public String userId() {
+        return "U12242134123423";
+    }
+
+    @Override
+    public String email() {
+        return "concierge@grookage.com";
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.grookage.concierge</groupId>
     <artifactId>concierge</artifactId>
-    <version>0.0.1-RC12</version>
+    <version>0.0.1-RC13</version>
     <packaging>pom</packaging>
 
     <name>Concierge</name>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
         <module>concierge-elastic-dw</module>
         <module>concierge-aerospike</module>
         <module>concierge-aerospike-dw</module>
+        <module>concierge-server-example</module>
     </modules>
     <description>RBAC enabled, versioned configuration service</description>
     <inceptionYear>2024</inceptionYear>


### PR DESCRIPTION
Fixed a weird bug with Aerospike usage. If there are no records OR only one record, Predicates don't work .and/.or, they need to be handled separately. Their [examples](https://github.com/aerospike/aerospike-client-java/blob/master/examples/src/com/aerospike/examples/QueryExp.java) and [forum](https://discuss.aerospike.com/t/querying-for-records-with-a-large-number-of-keys/11214) infact endorse the original code written, but found it during execution. After some semantic trials on aql - a large cup of coffee later - arrived at the structure that seems to work. 

Also added compression to Aerospike