### PR TITLE
Bug fix config create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [1.0.1]
 
-**Feature Addition** 
+**Feature Addition**
 
-Korg added a configConsumer when configs are getting refreshed, like a latch should the client want to consume the latch and do any post-processing. 
+Korg added a configConsumer when configs are getting refreshed, like a latch should the client want to consume the latch
+and do any post-processing.
 Updated korg version to have the changes reflected
 
 ## [1.0.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 - BugFix : Not allowing config create if configMeta exists already (org, namespace, configName, tenantId) or if there's
   any config in the created state with that meta
+- BugFix : Not allowing the config creator or updater to approve the config, previously it was only creator.
 - Removed the unnecessary recordExists method.
 
 ## [1.0.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.4]
+
+BugFix : History items 
+
 ## [1.0.3]
 
 - BugFix : Not allowing config create if configMeta exists already (org, namespace, configName, tenantId) or if there's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.3]
+
+- BugFix : Not allowing config create if configMeta exists already (org, namespace, configName, tenantId) or if there's
+  any config in the created state with that meta
+- Removed the unnecessary recordExists method.
+
 ## [1.0.1]
 
 **Feature Addition**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [1.0.4]
 
-BugFix : History items 
+BugFix : History items were not getting saved correctly because of equals and hashCode on configEvent - multiple updates are not getting saved properly. 
 
 ## [1.0.3]
 

--- a/concierge-aerospike-dw/pom.xml
+++ b/concierge-aerospike-dw/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-aerospike-dw/pom.xml
+++ b/concierge-aerospike-dw/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-aerospike-dw/pom.xml
+++ b/concierge-aerospike-dw/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-aerospike/pom.xml
+++ b/concierge-aerospike/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-aerospike/pom.xml
+++ b/concierge-aerospike/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-aerospike/pom.xml
+++ b/concierge-aerospike/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-aerospike/src/main/java/com/grookage/concierge/aerospike/client/AerospikeManager.java
+++ b/concierge-aerospike/src/main/java/com/grookage/concierge/aerospike/client/AerospikeManager.java
@@ -10,8 +10,6 @@ import com.grookage.concierge.aerospike.storage.AerospikeRecord;
 import com.grookage.concierge.aerospike.storage.AerospikeStorageConstants;
 import com.grookage.concierge.models.MapperUtils;
 import com.grookage.concierge.models.SearchRequest;
-import com.grookage.concierge.models.config.ConfigKey;
-import com.grookage.concierge.models.config.ConfigState;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -159,29 +157,5 @@ public class AerospikeManager {
             client.commit(transaction);
         }
         log.debug("Successfully completed the transaction with id {} and records {}", transaction.getId(), aerospikeRecords);
-    }
-
-    public boolean exists(final ConfigKey configKey) {
-        final var queryStatement = new Statement();
-        queryStatement.setNamespace(namespace);
-        queryStatement.setBinNames(AerospikeStorageConstants.DEFAULT_BIN);
-        queryStatement.setSetName(aerospikeConfig.getConfigSet());
-        final var queryPolicy = client.copyQueryPolicyDefault();
-        queryPolicy.filterExp = Exp.build(Exp.and(
-                Exp.eq(Exp.stringBin(AerospikeStorageConstants.ORG_BIN), Exp.val(configKey.getOrgId())),
-                Exp.eq(Exp.stringBin(AerospikeStorageConstants.NAMESPACE_BIN), Exp.val(configKey.getNamespace())),
-                Exp.eq(Exp.stringBin(AerospikeStorageConstants.TENANT_BIN), Exp.val(configKey.getTenantId())),
-                Exp.eq(Exp.stringBin(AerospikeStorageConstants.CONFIG_BIN), Exp.val(configKey.getConfigName())),
-                Exp.eq(Exp.stringBin(AerospikeStorageConstants.CONFIG_STATE_BIN), Exp.val(ConfigState.CREATED.name()))
-        ));
-        try (final var resultSet = client.query(queryPolicy, queryStatement)) {
-            var resultCount = 0;
-            while (resultSet.next()) {
-                if (null != resultSet.getRecord()) {
-                    resultCount++;
-                }
-            }
-            return resultCount > 0;
-        }
     }
 }

--- a/concierge-aerospike/src/main/java/com/grookage/concierge/aerospike/repository/AerospikeRepository.java
+++ b/concierge-aerospike/src/main/java/com/grookage/concierge/aerospike/repository/AerospikeRepository.java
@@ -6,7 +6,6 @@ import com.grookage.concierge.aerospike.storage.AerospikeRecord;
 import com.grookage.concierge.models.MapperUtils;
 import com.grookage.concierge.models.SearchRequest;
 import com.grookage.concierge.models.config.ConfigDetails;
-import com.grookage.concierge.models.config.ConfigKey;
 import com.grookage.concierge.models.config.ConfigState;
 import com.grookage.concierge.repository.ConciergeRepository;
 import lombok.Getter;
@@ -54,11 +53,6 @@ public class AerospikeRepository implements ConciergeRepository {
     public Optional<ConfigDetails> getStoredRecord(String referenceId) {
         return aerospikeManager.getRecord(referenceId)
                 .map(this::toConfigDetails);
-    }
-
-    @Override
-    public boolean createdRecordExists(ConfigKey configKey) {
-        return aerospikeManager.exists(configKey);
     }
 
     @Override

--- a/concierge-bom/pom.xml
+++ b/concierge-bom/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
     </parent>
 
     <artifactId>concierge-bom</artifactId>

--- a/concierge-bom/pom.xml
+++ b/concierge-bom/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4</version>
     </parent>
 
     <artifactId>concierge-bom</artifactId>

--- a/concierge-bom/pom.xml
+++ b/concierge-bom/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
     </parent>
 
     <artifactId>concierge-bom</artifactId>

--- a/concierge-client-dw/pom.xml
+++ b/concierge-client-dw/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-client-dw/pom.xml
+++ b/concierge-client-dw/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-client-dw/pom.xml
+++ b/concierge-client-dw/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-client/pom.xml
+++ b/concierge-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-client/pom.xml
+++ b/concierge-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-client/pom.xml
+++ b/concierge-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-core/pom.xml
+++ b/concierge-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-core/pom.xml
+++ b/concierge-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-core/pom.xml
+++ b/concierge-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-core/src/main/java/com/grookage/concierge/core/engine/processors/ApproveConfigProcessor.java
+++ b/concierge-core/src/main/java/com/grookage/concierge/core/engine/processors/ApproveConfigProcessor.java
@@ -42,7 +42,7 @@ public class ApproveConfigProcessor extends ConciergeProcessor {
                     configKey.getConfigName());
             throw ConciergeException.error(ConciergeCoreErrorCode.NO_CONFIG_FOUND);
         }
-        ConfigurationUtils.CONFIG_MAINTAINER_PREDICATE.test(storedConfig, context);
+        ConfigurationUtils.validateConfigApproveAccess(storedConfig, context);
         addHistory(context, storedConfig, null);
         storedConfig.setConfigState(ConfigState.APPROVED);
         getRepositorySupplier().get().update(storedConfig);

--- a/concierge-core/src/main/java/com/grookage/concierge/core/engine/processors/CreateConfigProcessor.java
+++ b/concierge-core/src/main/java/com/grookage/concierge/core/engine/processors/CreateConfigProcessor.java
@@ -3,8 +3,10 @@ package com.grookage.concierge.core.engine.processors;
 import com.grookage.concierge.core.engine.ConciergeContext;
 import com.grookage.concierge.core.engine.ConciergeProcessor;
 import com.grookage.concierge.core.utils.ConfigurationUtils;
+import com.grookage.concierge.models.SearchRequest;
 import com.grookage.concierge.models.config.ConfigDetails;
 import com.grookage.concierge.models.config.ConfigEvent;
+import com.grookage.concierge.models.config.ConfigState;
 import com.grookage.concierge.models.exception.ConciergeCoreErrorCode;
 import com.grookage.concierge.models.exception.ConciergeException;
 import com.grookage.concierge.models.ingestion.ConfigurationRequest;
@@ -14,6 +16,7 @@ import lombok.SneakyThrows;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.Set;
 import java.util.function.Supplier;
 
 @SuperBuilder
@@ -28,16 +31,28 @@ public class CreateConfigProcessor extends ConciergeProcessor {
         return ConfigEvent.CREATE_CONFIG;
     }
 
+    //Don't allow the same version config to be created again,
+    //Don't allow more than one created config
     @Override
     @SneakyThrows
     public void process(ConciergeContext context) {
         final var createConfigRequest = context.getContext(ConfigurationRequest.class)
                 .orElseThrow((Supplier<Throwable>) () -> ConciergeException.error(ConciergeCoreErrorCode.VALUE_NOT_FOUND));
-        final var recordExists = getRepositorySupplier()
+        final var configKey = createConfigRequest.getConfigKey();
+        final var searchRequest = SearchRequest.builder()
+                .orgs(Set.of(configKey.getOrgId()))
+                .tenants(Set.of(configKey.getTenantId()))
+                .namespaces(Set.of(configKey.getNamespace()))
+                .configNames(Set.of(configKey.getConfigName()))
+                .build();
+        final var storedConfigs = getRepositorySupplier()
                 .get()
-                .createdRecordExists(createConfigRequest.getConfigKey());
-        if (recordExists) {
-            log.error("There are already stored configs present with configKey {}. Please try updating them instead",
+                .getStoredRecords(searchRequest);
+        final var anyCreatedOrMatchingVersionConfig = storedConfigs.stream()
+                .anyMatch(each -> each.getConfigState() == ConfigState.CREATED ||
+                        each.getConfigKey().getVersion().equalsIgnoreCase(configKey.getVersion()));
+        if (anyCreatedOrMatchingVersionConfig) {
+            log.error("There are already stored configs present with configMeta {}. Please try updating them instead",
                     createConfigRequest.getConfigKey());
             throw ConciergeException.error(ConciergeCoreErrorCode.CONFIG_ALREADY_EXISTS);
         }

--- a/concierge-core/src/main/java/com/grookage/concierge/core/engine/processors/RejectConfigProcessor.java
+++ b/concierge-core/src/main/java/com/grookage/concierge/core/engine/processors/RejectConfigProcessor.java
@@ -2,7 +2,6 @@ package com.grookage.concierge.core.engine.processors;
 
 import com.grookage.concierge.core.engine.ConciergeContext;
 import com.grookage.concierge.core.engine.ConciergeProcessor;
-import com.grookage.concierge.core.utils.ConfigurationUtils;
 import com.grookage.concierge.models.config.ConfigDetails;
 import com.grookage.concierge.models.config.ConfigEvent;
 import com.grookage.concierge.models.config.ConfigKey;
@@ -46,7 +45,6 @@ public class RejectConfigProcessor extends ConciergeProcessor {
                     configKey.getConfigName());
             throw ConciergeException.error(ConciergeCoreErrorCode.NO_CONFIG_FOUND);
         }
-        ConfigurationUtils.CONFIG_MAINTAINER_PREDICATE.test(storedConfig, context);
         addHistory(context, storedConfig, null);
         storedConfig.setConfigState(ConfigState.REJECTED);
         getRepositorySupplier().get().update(storedConfig);

--- a/concierge-core/src/main/java/com/grookage/concierge/core/engine/processors/UpdateConfigProcessor.java
+++ b/concierge-core/src/main/java/com/grookage/concierge/core/engine/processors/UpdateConfigProcessor.java
@@ -44,7 +44,7 @@ public class UpdateConfigProcessor extends ConciergeProcessor {
             );
             throw ConciergeException.error(ConciergeCoreErrorCode.NO_CONFIG_FOUND);
         }
-        ConfigurationUtils.CONFIG_UPDATER_PREDICATE.test(storedConfig, context);
+        ConfigurationUtils.validateConfigUpdateAccess(storedConfig, context);
         storedConfig.setDescription(updateConfigRequest.getDescription());
         storedConfig.setData(MapperUtils.mapper().writeValueAsBytes(updateConfigRequest.getData()));
         addHistory(context, storedConfig, updateConfigRequest.getMessage());

--- a/concierge-core/src/main/java/com/grookage/concierge/core/engine/processors/UpdateConfigProcessor.java
+++ b/concierge-core/src/main/java/com/grookage/concierge/core/engine/processors/UpdateConfigProcessor.java
@@ -44,7 +44,6 @@ public class UpdateConfigProcessor extends ConciergeProcessor {
             );
             throw ConciergeException.error(ConciergeCoreErrorCode.NO_CONFIG_FOUND);
         }
-        ConfigurationUtils.validateConfigUpdateAccess(storedConfig, context);
         storedConfig.setDescription(updateConfigRequest.getDescription());
         storedConfig.setData(MapperUtils.mapper().writeValueAsBytes(updateConfigRequest.getData()));
         addHistory(context, storedConfig, updateConfigRequest.getMessage());

--- a/concierge-core/src/main/java/com/grookage/concierge/core/engine/processors/UpdateConfigProcessor.java
+++ b/concierge-core/src/main/java/com/grookage/concierge/core/engine/processors/UpdateConfigProcessor.java
@@ -2,7 +2,6 @@ package com.grookage.concierge.core.engine.processors;
 
 import com.grookage.concierge.core.engine.ConciergeContext;
 import com.grookage.concierge.core.engine.ConciergeProcessor;
-import com.grookage.concierge.core.utils.ConfigurationUtils;
 import com.grookage.concierge.models.MapperUtils;
 import com.grookage.concierge.models.config.ConfigDetails;
 import com.grookage.concierge.models.config.ConfigEvent;

--- a/concierge-core/src/main/java/com/grookage/concierge/core/utils/ConfigurationUtils.java
+++ b/concierge-core/src/main/java/com/grookage/concierge/core/utils/ConfigurationUtils.java
@@ -36,16 +36,6 @@ public class ConfigurationUtils {
         }
     }
 
-    public static void validateConfigUpdateAccess(final ConfigDetails configDetails, final ConciergeContext context) {
-        if (!LOCAL_ENV && CONFIG_PREDICATE.test(configDetails, context)) {
-            log.error("User {} is not allowed to update the config {}. Please contact the config creator {}",
-                    ContextUtils.getUserId(context),
-                    configDetails.getConfigKey(),
-                    getConfigCreatorId(configDetails));
-            throw ConciergeException.error(ConciergeCoreErrorCode.INVALID_USER);
-        }
-    }
-
     @SneakyThrows
     public ConfigDetails toConfigDetails(ConfigurationRequest configurationRequest) {
         return ConfigDetails.builder()

--- a/concierge-core/src/main/java/com/grookage/concierge/core/utils/ConfigurationUtils.java
+++ b/concierge-core/src/main/java/com/grookage/concierge/core/utils/ConfigurationUtils.java
@@ -19,19 +19,21 @@ import java.util.function.BiPredicate;
 public class ConfigurationUtils {
 
     private static final boolean LOCAL_ENV = Boolean.parseBoolean(System.getProperty("localEnv", "false"));
-
+    //Both config creator and configUpdater can't approve the config.
     private static final BiPredicate<ConfigDetails, ConciergeContext> CONFIG_PREDICATE = (configDetails, context) -> {
         final var requestingUser = ContextUtils.getUserId(context);
-        final var configCreatorId = ConfigurationUtils.getConfigCreatorId(configDetails);
-        return !requestingUser.equals(configCreatorId);
+        return configDetails.getConfigHistories()
+                .stream()
+                .filter(each -> each.getConfigEvent() == ConfigEvent.CREATE_CONFIG ||
+                        each.getConfigEvent() == ConfigEvent.UPDATE_CONFIG)
+                .anyMatch(each -> each.getConfigUpdaterId().equals(requestingUser));
     };
 
     public static void validateConfigApproveAccess(final ConfigDetails configDetails, final ConciergeContext context) {
-        if (!LOCAL_ENV && !CONFIG_PREDICATE.test(configDetails, context)) {
-            log.error("User {} is not allowed to approve the config {}. The userId is same as the config creator {}",
+        if (!LOCAL_ENV && CONFIG_PREDICATE.test(configDetails, context)) {
+            log.error("User {} is not allowed to approve the config {}. The userId is same as the config creator",
                     ContextUtils.getUserId(context),
-                    configDetails.getConfigKey(),
-                    getConfigCreatorId(configDetails));
+                    configDetails.getConfigKey());
             throw ConciergeException.error(ConciergeCoreErrorCode.INVALID_USER);
         }
     }
@@ -44,18 +46,5 @@ public class ConfigurationUtils {
                 .description(configurationRequest.getDescription())
                 .data(MapperUtils.mapper().writeValueAsBytes(configurationRequest.getData()))
                 .build();
-    }
-
-    public String getConfigCreatorId(final ConfigDetails configDetails) {
-        final var createConfigHistory = configDetails.getConfigHistories()
-                .stream()
-                .filter(each -> each.getConfigEvent() == ConfigEvent.CREATE_CONFIG)
-                .findFirst().orElse(null);
-        if (null == createConfigHistory) {
-            log.error("There is no history present for createConfig event for configKey {}. Please try creating the config first",
-                    configDetails.getConfigKey());
-            throw ConciergeException.error(ConciergeCoreErrorCode.NO_CONFIG_FOUND);
-        }
-        return createConfigHistory.getConfigUpdaterId();
     }
 }

--- a/concierge-core/src/main/java/com/grookage/concierge/core/utils/ContextUtils.java
+++ b/concierge-core/src/main/java/com/grookage/concierge/core/utils/ContextUtils.java
@@ -33,11 +33,11 @@ public class ContextUtils {
 
     private static final String USER_ID = "USER_ID";
 
-    public static void addConfigUpdaterContext(final ConciergeContext schemaContext,
+    public static void addConfigUpdaterContext(final ConciergeContext conciergeContext,
                                                final ConfigUpdater configUpdater) {
-        schemaContext.addContext(USER_NAME, configUpdater.name());
-        schemaContext.addContext(EMAIL, configUpdater.email());
-        schemaContext.addContext(USER_ID, configUpdater.userId());
+        conciergeContext.addContext(USER_NAME, configUpdater.name());
+        conciergeContext.addContext(EMAIL, configUpdater.email());
+        conciergeContext.addContext(USER_ID, configUpdater.userId());
     }
 
     @SneakyThrows

--- a/concierge-core/src/test/java/com/grookage/concierge/core/engine/CreateConfigProcessorTest.java
+++ b/concierge-core/src/test/java/com/grookage/concierge/core/engine/CreateConfigProcessorTest.java
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.util.List;
+
 class CreateConfigProcessorTest extends AbstractProcessorTest {
 
     @Override
@@ -21,17 +23,18 @@ class CreateConfigProcessorTest extends AbstractProcessorTest {
                 .build();
     }
 
-
     @Test
     @SneakyThrows
     void testConfigCreationActiveRecordExists() {
         final var conciergeContext = new ConciergeContext();
         final var createConfigRequest = ResourceHelper.getResource("configurationRequest.json",
                 ConfigurationRequest.class);
+        final var configDetails = ResourceHelper.getResource("configDetails.json",
+                ConfigDetails.class);
         conciergeContext.addContext(ConfigurationRequest.class.getSimpleName(), createConfigRequest);
         ContextUtils.addConfigUpdaterContext(conciergeContext, getConfigUpdater());
-        Mockito.when(getConciergeRepository().createdRecordExists(Mockito.any()))
-                .thenReturn(true);
+        Mockito.when(getConciergeRepository().getStoredRecords(Mockito.any()))
+                .thenReturn(List.of(configDetails));
         final var processor = getConciergeProcessor();
         Assertions.assertThrows(ConciergeException.class, () -> processor.process(conciergeContext));
     }
@@ -44,8 +47,8 @@ class CreateConfigProcessorTest extends AbstractProcessorTest {
                 ConfigurationRequest.class);
         conciergeContext.addContext(ConfigurationRequest.class.getSimpleName(), createConfigRequest);
         ContextUtils.addConfigUpdaterContext(conciergeContext, getConfigUpdater());
-        Mockito.when(getConciergeRepository().createdRecordExists(Mockito.any()))
-                .thenReturn(false);
+        Mockito.when(getConciergeRepository().getStoredRecords(Mockito.any()))
+                .thenReturn(List.of());
         final var processor = getConciergeProcessor();
         processor.process(conciergeContext);
         Mockito.verify(getConciergeRepository(), Mockito.times(1))

--- a/concierge-core/src/test/java/com/grookage/concierge/core/engine/UpdateConfigProcessorTest.java
+++ b/concierge-core/src/test/java/com/grookage/concierge/core/engine/UpdateConfigProcessorTest.java
@@ -47,7 +47,7 @@ class UpdateConfigProcessorTest extends AbstractProcessorTest {
         configDetails.addHistory(
                 ConfigHistoryItem.builder()
                         .configEvent(ConfigEvent.CREATE_CONFIG)
-                        .configUpdaterId("updaterId")
+                        .configUpdaterId("userId")
                         .build()
         );
         Mockito.when(getConciergeRepository().getStoredRecord(Mockito.any(ConfigKey.class)))

--- a/concierge-core/src/test/java/com/grookage/concierge/core/utils/ConfigurationUtilsTest.java
+++ b/concierge-core/src/test/java/com/grookage/concierge/core/utils/ConfigurationUtilsTest.java
@@ -1,0 +1,94 @@
+package com.grookage.concierge.core.utils;
+
+import com.grookage.concierge.core.engine.ConciergeContext;
+import com.grookage.concierge.models.ConfigUpdater;
+import com.grookage.concierge.models.ResourceHelper;
+import com.grookage.concierge.models.config.ConfigDetails;
+import com.grookage.concierge.models.config.ConfigEvent;
+import com.grookage.concierge.models.config.ConfigHistoryItem;
+import com.grookage.concierge.models.exception.ConciergeException;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class ConfigurationUtilsTest {
+
+    private static final ConfigUpdater testUpdater = new ConfigUpdater() {
+        @Override
+        public String name() {
+            return "n";
+        }
+
+        @Override
+        public String userId() {
+            return "U1";
+        }
+
+        @Override
+        public String email() {
+            return "email";
+        }
+    };
+
+    @Test
+    @SneakyThrows
+    void testConfigApprovalInValidUser() {
+        final var configDetails = ResourceHelper.getResource(
+                "configDetails.json",
+                ConfigDetails.class
+        );
+        final var history = ResourceHelper.getResource(
+                "configHistory.json",
+                ConfigHistoryItem.class
+        );
+        configDetails.addHistory(history);
+        final var context = new ConciergeContext();
+        ContextUtils.addConfigUpdaterContext(context, testUpdater);
+        Assertions.assertThrows(ConciergeException.class, () -> ConfigurationUtils.validateConfigApproveAccess(
+                configDetails,
+                context
+        ));
+    }
+
+    @Test
+    @SneakyThrows
+    void testConfigApprovalSameUserIdOtherState() {
+        final var configDetails = ResourceHelper.getResource(
+                "configDetails.json",
+                ConfigDetails.class
+        );
+        final var history = ResourceHelper.getResource(
+                "configHistory.json",
+                ConfigHistoryItem.class
+        );
+        history.setConfigEvent(ConfigEvent.APPROVE_CONFIG);
+        configDetails.addHistory(history);
+        final var context = new ConciergeContext();
+        ContextUtils.addConfigUpdaterContext(context, testUpdater);
+        Assertions.assertDoesNotThrow(() -> ConfigurationUtils.validateConfigApproveAccess(
+                configDetails,
+                context
+        ));
+    }
+
+    @Test
+    @SneakyThrows
+    void testConfigApprovalValidUser() {
+        final var configDetails = ResourceHelper.getResource(
+                "configDetails.json",
+                ConfigDetails.class
+        );
+        final var history = ResourceHelper.getResource(
+                "configHistory.json",
+                ConfigHistoryItem.class
+        );
+        history.setConfigUpdaterId("ccc1");
+        configDetails.addHistory(history);
+        final var context = new ConciergeContext();
+        ContextUtils.addConfigUpdaterContext(context, testUpdater);
+        Assertions.assertDoesNotThrow(() -> ConfigurationUtils.validateConfigApproveAccess(
+                configDetails,
+                context
+        ));
+    }
+}

--- a/concierge-dw/pom.xml
+++ b/concierge-dw/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-dw/pom.xml
+++ b/concierge-dw/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-dw/pom.xml
+++ b/concierge-dw/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-elastic-dw/pom.xml
+++ b/concierge-elastic-dw/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-elastic-dw/pom.xml
+++ b/concierge-elastic-dw/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-elastic-dw/pom.xml
+++ b/concierge-elastic-dw/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-elastic/pom.xml
+++ b/concierge-elastic/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-elastic/pom.xml
+++ b/concierge-elastic/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-elastic/pom.xml
+++ b/concierge-elastic/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-models/pom.xml
+++ b/concierge-models/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-models/pom.xml
+++ b/concierge-models/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-models/pom.xml
+++ b/concierge-models/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-models/src/main/java/com/grookage/concierge/models/config/ConfigHistoryItem.java
+++ b/concierge-models/src/main/java/com/grookage/concierge/models/config/ConfigHistoryItem.java
@@ -26,21 +26,4 @@ public class ConfigHistoryItem {
     String configUpdaterId;
     String configUpdaterEmail;
     String message;
-
-    @Override
-    public int hashCode() {
-        return this.getConfigEvent().hashCode();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null || obj.getClass() != this.getClass()) {
-            return false;
-        }
-        final var thatKey = (ConfigHistoryItem) obj;
-        return (thatKey.getConfigEvent().equals(this.configEvent));
-    }
 }

--- a/concierge-models/src/main/java/com/grookage/concierge/models/config/ConfigHistoryItem.java
+++ b/concierge-models/src/main/java/com/grookage/concierge/models/config/ConfigHistoryItem.java
@@ -22,6 +22,7 @@ public class ConfigHistoryItem {
     long timestamp;
     @NotBlank
     String configUpdaterName;
+    @NotBlank
     String configUpdaterId;
     String configUpdaterEmail;
     String message;

--- a/concierge-models/src/test/resources/configHistory.json
+++ b/concierge-models/src/test/resources/configHistory.json
@@ -1,5 +1,6 @@
 {
   "configEvent": "CREATE_CONFIG",
   "timestamp": "0",
-  "configUpdaterName": "conciergeUser"
+  "configUpdaterName": "conciergeUser",
+  "configUpdaterId": "U1"
 }

--- a/concierge-parent/pom.xml
+++ b/concierge-parent/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-bom</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
         <relativePath>../concierge-bom</relativePath>
     </parent>
 

--- a/concierge-parent/pom.xml
+++ b/concierge-parent/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-bom</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4</version>
         <relativePath>../concierge-bom</relativePath>
     </parent>
 

--- a/concierge-parent/pom.xml
+++ b/concierge-parent/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-bom</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
         <relativePath>../concierge-bom</relativePath>
     </parent>
 

--- a/concierge-repository/pom.xml
+++ b/concierge-repository/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-repository/pom.xml
+++ b/concierge-repository/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-repository/pom.xml
+++ b/concierge-repository/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-repository/src/main/java/com/grookage/concierge/repository/ConciergeRepository.java
+++ b/concierge-repository/src/main/java/com/grookage/concierge/repository/ConciergeRepository.java
@@ -19,8 +19,6 @@ public interface ConciergeRepository {
         return getStoredRecord(configKey.getReferenceId());
     }
 
-    boolean createdRecordExists(ConfigKey configKey);
-
     List<ConfigDetails> getStoredRecords();
 
     List<ConfigDetails> getStoredRecords(SearchRequest searchRequest);

--- a/concierge-server-example/pom.xml
+++ b/concierge-server-example/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-server-example/pom.xml
+++ b/concierge-server-example/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-server-example/pom.xml
+++ b/concierge-server-example/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.grookage.concierge</groupId>
     <artifactId>concierge</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <packaging>pom</packaging>
 
     <name>Concierge</name>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.grookage.concierge</groupId>
     <artifactId>concierge</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <packaging>pom</packaging>
 
     <name>Concierge</name>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.grookage.concierge</groupId>
     <artifactId>concierge</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
     <packaging>pom</packaging>
 
     <name>Concierge</name>


### PR DESCRIPTION
- BugFix : Not allowing config create if configMeta exists already (org, namespace, configName, tenantId) or if there's
  any config in the created state with that meta
- Removed the unnecessary recordExists method.