### PR TITLE
Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,4 +41,8 @@ target/
 */test-classes/*
 \$*
 .DS_Store
+.classpath
+.factorypath
+.project
+.settings/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.7]
+
+**Features**
+- Added pagination support via `PageWindow` in `SearchRequest` with configurable `page` and `pageSize`
+- Pagination applied across all repository implementations (Aerospike, Elasticsearch) and in-memory cache
+
+**Improvements**
+- `ConfigServiceImpl.getConfigs` now fetches cached and non-cached config types in parallel using `CompletableFuture`, improving performance for mixed queries
+- `SearchRequest` now supports `toBuilder()` for easier request modification
+- Code cleanup: Replaced imperative patterns with streams and `Optional` chaining in `ConfigRegistry`
+    - `computeIfAbsent` for nested map operations
+    - Stream-based filtering in `getMatchingConfigs`
+    - `Optional.ofNullable().map()` in `getConfigDetails`
+- `CacheConfig.cachedType` simplified to use `equalsIgn
+
 ## [1.0.6]
 
 - BugFix: Data in repository record is not getting updated correctly as part of bulkUpdate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,20 @@
 All notable changes to this project will be documented in this file.
 
 ## [1.0.6]
+
 - BugFix: Data in repository record is not getting updated correctly as part of bulkUpdate
 - BugFix: Added missing configType in searchRequest during bulkUpdate
 
 ## [1.0.5]
-- BugFix: ProcessorKey configEvent was not getting saved correctly in the `IngestionServiceImpl` for different configTypes.
+
+- BugFix: ProcessorKey configEvent was not getting saved correctly in the `IngestionServiceImpl` for different
+  configTypes.
 - Added tests for the IngestionService
 
 ## [1.0.4]
 
-BugFix : History items were not getting saved correctly because of equals and hashCode on configEvent - multiple updates are not getting saved properly. 
+BugFix : History items were not getting saved correctly because of equals and hashCode on configEvent - multiple updates
+are not getting saved properly.
 
 ## [1.0.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to this project will be documented in this file.
     - `computeIfAbsent` for nested map operations
     - Stream-based filtering in `getMatchingConfigs`
     - `Optional.ofNullable().map()` in `getConfigDetails`
-- `CacheConfig.cachedType` simplified to use `equalsIgn
+- `CacheConfig.cachedType` simplified to use `equalsIgnoreCase` for case-insensitive matching
 
 ## [1.0.6]
 

--- a/concierge-aerospike-dw/pom.xml
+++ b/concierge-aerospike-dw/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>1.0.6</version>
+        <version>1.0.7</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-aerospike/pom.xml
+++ b/concierge-aerospike/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>1.0.6</version>
+        <version>1.0.7</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-aerospike/src/main/java/com/grookage/concierge/aerospike/client/AerospikeManager.java
+++ b/concierge-aerospike/src/main/java/com/grookage/concierge/aerospike/client/AerospikeManager.java
@@ -1,7 +1,7 @@
 package com.grookage.concierge.aerospike.client;
 
-import com.aerospike.client.Record;
 import com.aerospike.client.*;
+import com.aerospike.client.Record;
 import com.aerospike.client.exp.Exp;
 import com.aerospike.client.policy.RecordExistsAction;
 import com.aerospike.client.policy.WritePolicy;
@@ -103,7 +103,8 @@ public class AerospikeManager {
         queryStatement.setNamespace(namespace);
         queryStatement.setBinNames(AerospikeStorageConstants.DEFAULT_BIN);
         queryStatement.setSetName(aerospikeConfig.getConfigSet());
-        queryStatement.setMaxRecords(10000);
+        final var pageWindow = searchRequest.getPageWindow();
+        queryStatement.setMaxRecords(pageWindow.offset() + pageWindow.getPageSize());
         final var queryPolicy = client.copyQueryPolicyDefault();
         final var searchableExpressions = new ArrayList<Exp>();
         augmentExpressions(AerospikeStorageConstants.NAMESPACE_BIN, searchRequest.getNamespaces(), searchableExpressions);
@@ -121,20 +122,26 @@ public class AerospikeManager {
             }
         }
         final var aerospikeRecords = new ArrayList<AerospikeRecord>();
+        int skipped = 0;
+        int collected = 0;
         try (final var rs = client.query(queryPolicy, queryStatement)) {
-            while (rs.next()) {
+            while (rs.next() && collected < pageWindow.getPageSize()) {
                 final var storageRecord = rs.getRecord();
-                if (null != storageRecord) {
-                    final var binRecord = storageRecord.getBytes(AerospikeStorageConstants.DEFAULT_BIN);
-                    if (null != binRecord) {
-                        aerospikeRecords.add(
-                                MapperUtils.mapper().readValue(AerospikeClientUtils.retrieve(binRecord),
-                                        AerospikeRecord.class)
-                        );
-                    }
-                }
+                if (storageRecord == null) continue;
+
+                final var binRecord = storageRecord.getBytes(AerospikeStorageConstants.DEFAULT_BIN);
+                if (binRecord == null) continue;
+
+                if (skipped++ < pageWindow.offset()) continue;
+
+                aerospikeRecords.add(
+                        MapperUtils.mapper().readValue(AerospikeClientUtils.retrieve(binRecord),
+                                AerospikeRecord.class)
+                );
+                collected++;
             }
         }
+
         return aerospikeRecords;
     }
 
@@ -156,7 +163,7 @@ public class AerospikeManager {
             if (aerospikeConfig.isTxnEnabled()) {
                 client.abort(transaction);
             }
-            throw ConciergeException.error(ConciergeAeroErrorCode.BULK_UPDATE_FAILED,e);
+            throw ConciergeException.error(ConciergeAeroErrorCode.BULK_UPDATE_FAILED, e);
         } finally {
             if (aerospikeConfig.isTxnEnabled()) {
                 client.commit(transaction);

--- a/concierge-aerospike/src/main/java/com/grookage/concierge/aerospike/repository/AerospikeRepository.java
+++ b/concierge-aerospike/src/main/java/com/grookage/concierge/aerospike/repository/AerospikeRepository.java
@@ -52,15 +52,9 @@ public class AerospikeRepository implements ConciergeRepository {
     }
 
     @Override
-    public Optional<ConfigDetails> getStoredRecord(String referenceId) {
+    public Optional<ConfigDetails> getStoredRecord(String configType, String referenceId) {
         return aerospikeManager.getRecord(referenceId)
                 .map(this::toConfigDetails);
-    }
-
-    @Override
-    public List<ConfigDetails> getStoredRecords() {
-        return aerospikeManager.getRecords(SearchRequest.builder().build())
-                .stream().map(this::toConfigDetails).toList();
     }
 
     @Override

--- a/concierge-bom/pom.xml
+++ b/concierge-bom/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge</artifactId>
-        <version>1.0.6</version>
+        <version>1.0.7</version>
     </parent>
 
     <name>Concierge BOM</name>

--- a/concierge-client-dw/pom.xml
+++ b/concierge-client-dw/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>1.0.6</version>
+        <version>1.0.7</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-client/pom.xml
+++ b/concierge-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>1.0.6</version>
+        <version>1.0.7</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-core/pom.xml
+++ b/concierge-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>1.0.6</version>
+        <version>1.0.7</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-core/src/main/java/com/grookage/concierge/core/cache/CacheConfig.java
+++ b/concierge-core/src/main/java/com/grookage/concierge/core/cache/CacheConfig.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.Set;
+
 @AllArgsConstructor
 @Data
 @Builder
@@ -15,5 +17,12 @@ public class CacheConfig {
 
     private boolean enabled;
     @Builder.Default
+    private Set<String> configTypes = Set.of();
+    @Builder.Default
     private int refreshCacheSeconds = 10;
+
+    public boolean cachedType(final String configType) {
+        return configTypes != null && configTypes.stream()
+                .anyMatch(each -> each.equalsIgnoreCase(configType));
+    }
 }

--- a/concierge-core/src/main/java/com/grookage/concierge/core/cache/ConfigRegistry.java
+++ b/concierge-core/src/main/java/com/grookage/concierge/core/cache/ConfigRegistry.java
@@ -1,27 +1,62 @@
 package com.grookage.concierge.core.cache;
 
+import com.grookage.concierge.models.CollectionUtils;
+import com.grookage.concierge.models.SearchRequest;
 import com.grookage.concierge.models.config.ConfigDetails;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 @Slf4j
 public class ConfigRegistry {
 
-    private final ConcurrentHashMap<String, ConfigDetails> schemas = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, ConcurrentHashMap<String, ConfigDetails>> configSchemas = new ConcurrentHashMap<>();
+
+    private String getCasedString(final String key) {
+        return key.toUpperCase(Locale.ROOT);
+    }
 
     public void add(final ConfigDetails configDetails) {
-        schemas.putIfAbsent(configDetails.getConfigKey().getReferenceId(), configDetails);
+        configSchemas.computeIfAbsent(getCasedString(configDetails.getConfigKey().getConfigType()), k -> new ConcurrentHashMap<>())
+                .putIfAbsent(configDetails.getConfigKey().getReferenceId(), configDetails);
     }
 
-    public Collection<ConfigDetails> getConfigs() {
-        return schemas.values();
+    public List<ConfigDetails> getMatchingConfigs(final SearchRequest searchRequest) {
+        final var pageWindow = searchRequest.getPageWindow();
+        return searchRequest.getConfigTypes().stream()
+                .map(configType -> configSchemas.get(getCasedString(configType)))
+                .filter(Objects::nonNull)
+                .flatMap(configs -> configs.values().stream())
+                .filter(config -> match(config, searchRequest))
+                .skip(pageWindow.offset())
+                .limit(pageWindow.getPageSize())
+                .collect(Collectors.toList());
     }
 
-    public Optional<ConfigDetails> getConfiguration(final String referenceId) {
-        return Optional.ofNullable(schemas.get(referenceId));
+    public Optional<ConfigDetails> getConfigDetails(final String configType, final String referenceId) {
+        return Optional.ofNullable(configSchemas.get(getCasedString(configType)))
+                .map(configs -> configs.get(referenceId));
+    }
+
+    private boolean match(ConfigDetails configDetails, SearchRequest searchRequest) {
+        final var configKey = configDetails.getConfigKey();
+        final var namespaceMatch = CollectionUtils.isNullOrEmpty(searchRequest.getNamespaces()) ||
+                searchRequest.getNamespaces().contains(configKey.getNamespace());
+        final var configNameMatch = CollectionUtils.isNullOrEmpty(searchRequest.getConfigNames()) ||
+                searchRequest.getConfigNames().contains(configKey.getConfigName());
+        final var configStateMatch = CollectionUtils.isNullOrEmpty(searchRequest.getConfigStates()) ||
+                searchRequest.getConfigStates().contains(configDetails.getConfigState());
+        final var orgMatch = CollectionUtils.isNullOrEmpty(searchRequest.getOrgs()) ||
+                searchRequest.getOrgs().contains(configKey.getOrgId());
+        final var tenantMatch = CollectionUtils.isNullOrEmpty(searchRequest.getTenants()) ||
+                searchRequest.getTenants().contains(configKey.getTenantId());
+        return namespaceMatch && configNameMatch && configStateMatch
+                && orgMatch && tenantMatch;
     }
 
 }

--- a/concierge-core/src/main/java/com/grookage/concierge/core/cache/RepositorySupplier.java
+++ b/concierge-core/src/main/java/com/grookage/concierge/core/cache/RepositorySupplier.java
@@ -1,9 +1,11 @@
 package com.grookage.concierge.core.cache;
 
+import com.grookage.concierge.models.SearchRequest;
 import com.grookage.concierge.repository.ConciergeRepository;
 import com.grookage.korg.suppliers.KorgSupplier;
 import lombok.AllArgsConstructor;
 
+import java.util.Set;
 import java.util.function.Supplier;
 
 
@@ -11,6 +13,7 @@ import java.util.function.Supplier;
 public class RepositorySupplier implements KorgSupplier<ConfigRegistry> {
 
     private final Supplier<ConciergeRepository> repositorySupplier;
+    private final Set<String> configTypes;
 
     @Override
     public void start() {
@@ -24,7 +27,10 @@ public class RepositorySupplier implements KorgSupplier<ConfigRegistry> {
 
     @Override
     public ConfigRegistry get() {
-        final var configDetails = repositorySupplier.get().getStoredRecords();
+        final var searchRequest = SearchRequest.builder()
+                .configTypes(configTypes)
+                .build();
+        final var configDetails = repositorySupplier.get().getStoredRecords(searchRequest);
         final var registry = new ConfigRegistry();
         configDetails.forEach(registry::add);
         return registry;

--- a/concierge-core/src/main/java/com/grookage/concierge/core/engine/processors/ActivateConfigProcessor.java
+++ b/concierge-core/src/main/java/com/grookage/concierge/core/engine/processors/ActivateConfigProcessor.java
@@ -1,5 +1,3 @@
-
-
 package com.grookage.concierge.core.engine.processors;
 
 import com.grookage.concierge.core.engine.ConciergeContext;

--- a/concierge-core/src/main/java/com/grookage/concierge/core/engine/processors/ActivateConfigProcessor.java
+++ b/concierge-core/src/main/java/com/grookage/concierge/core/engine/processors/ActivateConfigProcessor.java
@@ -1,3 +1,5 @@
+
+
 package com.grookage.concierge.core.engine.processors;
 
 import com.grookage.concierge.core.engine.ConciergeContext;
@@ -38,6 +40,12 @@ public class ActivateConfigProcessor extends ConciergeProcessor {
         final var configKey = context.getContext(ConfigKey.class)
                 .orElseThrow((Supplier<Throwable>) () -> ConciergeException.error(ConciergeCoreErrorCode.VALUE_NOT_FOUND));
         final var storedConfig = getRepositorySupplier().get().getStoredRecord(configKey).orElse(null);
+
+        if (null != storedConfig && storedConfig.getConfigState() == ConfigState.ACTIVATED) {
+            log.warn("Looks like the ActivateConfigProcessor is being retried, the config is already in approved state, for Configkey {}, Doing nothing.", configKey);
+            return;
+        }
+
         if (null == storedConfig || !ACCEPTABLE_STATES.contains(storedConfig.getConfigState())) {
             log.error("There are no stored configs present with namespace {}, version {} and configName {}. Please try updating them instead",
                     configKey.getNamespace(),
@@ -55,3 +63,4 @@ public class ActivateConfigProcessor extends ConciergeProcessor {
         context.addContext(ConfigDetails.class.getSimpleName(), storedConfig);
     }
 }
+

--- a/concierge-core/src/main/java/com/grookage/concierge/core/engine/processors/ApproveConfigProcessor.java
+++ b/concierge-core/src/main/java/com/grookage/concierge/core/engine/processors/ApproveConfigProcessor.java
@@ -35,6 +35,12 @@ public class ApproveConfigProcessor extends ConciergeProcessor {
         final var configKey = context.getContext(ConfigKey.class)
                 .orElseThrow((Supplier<Throwable>) () -> ConciergeException.error(ConciergeCoreErrorCode.VALUE_NOT_FOUND));
         final var storedConfig = getRepositorySupplier().get().getStoredRecord(configKey).orElse(null);
+
+        if (null != storedConfig && storedConfig.getConfigState() == ConfigState.APPROVED) {
+            log.warn("Looks like the ApproveConfigProcessor is being retried, the config is already in approved state, for Configkey {}, Doing nothing.", configKey);
+            return;
+        }
+
         if (null == storedConfig || storedConfig.getConfigState() != ConfigState.CREATED) {
             log.error("There are no stored configs present with namespace {}, version {} and configName {}. Please try updating them instead",
                     configKey.getNamespace(),
@@ -42,6 +48,7 @@ public class ApproveConfigProcessor extends ConciergeProcessor {
                     configKey.getConfigName());
             throw ConciergeException.error(ConciergeCoreErrorCode.NO_CONFIG_FOUND);
         }
+
         ConfigurationUtils.validateConfigApproveAccess(storedConfig, context);
         addHistory(context, storedConfig, null);
         storedConfig.setConfigState(ConfigState.APPROVED);
@@ -49,3 +56,4 @@ public class ApproveConfigProcessor extends ConciergeProcessor {
         context.addContext(ConfigDetails.class.getSimpleName(), storedConfig);
     }
 }
+

--- a/concierge-core/src/main/java/com/grookage/concierge/core/engine/processors/CreateConfigProcessor.java
+++ b/concierge-core/src/main/java/com/grookage/concierge/core/engine/processors/CreateConfigProcessor.java
@@ -48,10 +48,19 @@ public class CreateConfigProcessor extends ConciergeProcessor {
         final var storedConfigs = getRepositorySupplier()
                 .get()
                 .getStoredRecords(searchRequest);
-        final var anyCreatedOrMatchingVersionConfig = storedConfigs.stream()
-                .anyMatch(each -> each.getConfigState() == ConfigState.CREATED ||
-                        each.getConfigKey().getVersion().equalsIgnoreCase(configKey.getVersion()));
-        if (anyCreatedOrMatchingVersionConfig) {
+
+        final var alreadyCreatedConfig = storedConfigs.stream()
+                .anyMatch(each -> each.getConfigState() == ConfigState.CREATED);
+
+        if (alreadyCreatedConfig) {
+            log.warn("The config {} has been created already. Doing nothing. Possibly a retry of the same action", configKey);
+            return;
+        }
+
+        final var anyMatchingVersionConfig = storedConfigs.stream()
+                .anyMatch(each -> each.getConfigKey().getVersion().equalsIgnoreCase(configKey.getVersion()));
+
+        if (anyMatchingVersionConfig) {
             log.error("There are already stored configs present with configMeta {}. Please try updating them instead",
                     createConfigRequest.getConfigKey());
             throw ConciergeException.error(ConciergeCoreErrorCode.CONFIG_ALREADY_EXISTS);
@@ -62,3 +71,4 @@ public class CreateConfigProcessor extends ConciergeProcessor {
         context.addContext(ConfigDetails.class.getSimpleName(), configDetails);
     }
 }
+

--- a/concierge-core/src/main/java/com/grookage/concierge/core/engine/processors/RejectConfigProcessor.java
+++ b/concierge-core/src/main/java/com/grookage/concierge/core/engine/processors/RejectConfigProcessor.java
@@ -38,6 +38,12 @@ public class RejectConfigProcessor extends ConciergeProcessor {
         final var configKey = context.getContext(ConfigKey.class)
                 .orElseThrow((Supplier<Throwable>) () -> ConciergeException.error(ConciergeCoreErrorCode.VALUE_NOT_FOUND));
         final var storedConfig = getRepositorySupplier().get().getStoredRecord(configKey).orElse(null);
+
+        if (null != storedConfig && storedConfig.getConfigState() == ConfigState.REJECTED) {
+            log.warn("Looks like the RejectConfigProcessor is being retried, the config is already in approved state, for Configkey {}, Doing nothing.", configKey);
+            return;
+        }
+
         if (null == storedConfig || !ACCEPTABLE_STATES.contains(storedConfig.getConfigState())) {
             log.error("There are no stored configs present with namespace {}, version {} and configName {}. Please try updating them instead",
                     configKey.getNamespace(),
@@ -51,3 +57,4 @@ public class RejectConfigProcessor extends ConciergeProcessor {
         context.addContext(ConfigDetails.class.getSimpleName(), storedConfig);
     }
 }
+

--- a/concierge-core/src/main/java/com/grookage/concierge/core/engine/resolver/ConfigVersionManager.java
+++ b/concierge-core/src/main/java/com/grookage/concierge/core/engine/resolver/ConfigVersionManager.java
@@ -1,7 +1,10 @@
 package com.grookage.concierge.core.engine.resolver;
 
+import com.grookage.concierge.models.config.ConfigKey;
+
 public interface ConfigVersionManager {
 
     boolean enableMultipleConfigs(String configType);
 
+    String generateConfigVersion(ConfigKey configKey);
 }

--- a/concierge-core/src/main/java/com/grookage/concierge/core/engine/resolver/DefaultConfigVersionManager.java
+++ b/concierge-core/src/main/java/com/grookage/concierge/core/engine/resolver/DefaultConfigVersionManager.java
@@ -1,5 +1,6 @@
 package com.grookage.concierge.core.engine.resolver;
 
+import com.grookage.concierge.models.config.ConfigKey;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
@@ -7,5 +8,10 @@ public class DefaultConfigVersionManager implements ConfigVersionManager {
     @Override
     public boolean enableMultipleConfigs(String configType) {
         return false;
+    }
+
+    @Override
+    public String generateConfigVersion(ConfigKey configKey) {
+        return configKey.getVersion();
     }
 }

--- a/concierge-core/src/main/java/com/grookage/concierge/core/services/ConfigService.java
+++ b/concierge-core/src/main/java/com/grookage/concierge/core/services/ConfigService.java
@@ -12,7 +12,7 @@ import java.util.function.Consumer;
 
 public interface ConfigService {
 
-    Optional<ConfigDetails> getConfig(ConciergeRequestContext requestContext, String referenceId);
+    Optional<ConfigDetails> getConfig(ConciergeRequestContext requestContext, String configType, String referenceId);
 
     Optional<ConfigDetails> getConfig(ConciergeRequestContext requestContext, ConfigKey configKey);
 

--- a/concierge-core/src/main/java/com/grookage/concierge/core/services/impl/ConfigServiceImpl.java
+++ b/concierge-core/src/main/java/com/grookage/concierge/core/services/impl/ConfigServiceImpl.java
@@ -5,7 +5,6 @@ import com.grookage.concierge.core.cache.ConfigRegistry;
 import com.grookage.concierge.core.cache.RepositoryRefresher;
 import com.grookage.concierge.core.cache.RepositorySupplier;
 import com.grookage.concierge.core.services.ConfigService;
-import com.grookage.concierge.models.CollectionUtils;
 import com.grookage.concierge.models.SearchRequest;
 import com.grookage.concierge.models.config.ConciergeRequestContext;
 import com.grookage.concierge.models.config.ConfigDetails;
@@ -17,8 +16,11 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Slf4j
 public class ConfigServiceImpl implements ConfigService {
@@ -34,7 +36,7 @@ public class ConfigServiceImpl implements ConfigService {
         this.repositorySupplier = repositorySupplier;
         this.cacheConfig = cacheConfig;
         if (null != cacheConfig && cacheConfig.isEnabled()) {
-            final var supplier = new RepositorySupplier(repositorySupplier);
+            final var supplier = new RepositorySupplier(repositorySupplier, cacheConfig.getConfigTypes());
             supplier.start();
             this.refresher = RepositoryRefresher.builder()
                     .supplier(supplier)
@@ -47,57 +49,63 @@ public class ConfigServiceImpl implements ConfigService {
     }
 
     @Override
-    public Optional<ConfigDetails> getConfig(ConciergeRequestContext requestContext, String referenceId) {
-        final var useCache = useRepositoryCache(requestContext);
-        return useCache ? refresher.getData().getConfiguration(referenceId) :
-                repositorySupplier.get().getStoredRecord(referenceId);
+    public Optional<ConfigDetails> getConfig(ConciergeRequestContext requestContext, String configType, String referenceId) {
+        final var useCache = useRepositoryCache(requestContext, configType);
+        return useCache ? refresher.getData().getConfigDetails(configType, referenceId) :
+                repositorySupplier.get().getStoredRecord(configType, referenceId);
     }
 
     @Override
     public Optional<ConfigDetails> getConfig(ConciergeRequestContext requestContext, ConfigKey configKey) {
-        return getConfig(requestContext, configKey.getReferenceId());
+        return getConfig(requestContext, configKey.getConfigType(), configKey.getReferenceId());
     }
 
     @Override
     public List<ConfigDetails> getConfigs(ConciergeRequestContext requestContext, SearchRequest searchRequest) {
-        if (!useRepositoryCache(requestContext)) {
+        if (!cacheEnabled(requestContext)) {
+            log.debug("There is no cache enabled for the requestContext, fetching the configs directly from the repository directly");
             return repositorySupplier.get().getStoredRecords(searchRequest);
         }
-        return refresher.getData().getConfigs().stream()
-                .filter(each -> match(each, searchRequest))
-                .toList();
+
+        var partitioned = searchRequest.getConfigTypes().stream()
+                .collect(Collectors.partitioningBy(cacheConfig::cachedType, Collectors.toSet()));
+        var cachedTypes = partitioned.get(true);
+        var nonCachedTypes = partitioned.get(false);
+
+        var cacheFuture = cachedTypes.isEmpty()
+                ? CompletableFuture.completedFuture(List.<ConfigDetails>of())
+                : CompletableFuture.supplyAsync(() ->
+                refresher.getData().getMatchingConfigs(searchRequest.toBuilder().configTypes(cachedTypes).build()));
+
+        var repoFuture = nonCachedTypes.isEmpty()
+                ? CompletableFuture.completedFuture(List.<ConfigDetails>of())
+                : CompletableFuture.supplyAsync(() ->
+                repositorySupplier.get().getStoredRecords(searchRequest.toBuilder().configTypes(nonCachedTypes).build()));
+
+        return cacheFuture.thenCombine(repoFuture, (cached, repo) ->
+                Stream.concat(cached.stream(), repo.stream()).toList()
+        ).join();
     }
 
     @Override
     public Optional<Consumer<ConfigRegistry>> getConfigConsumer(ConciergeRequestContext requestContext) {
-        if (!useRepositoryCache(requestContext)) {
+        if (!cacheEnabled(requestContext)) {
             log.debug("There is no cache context enabled, returning the empty config consumer");
             return Optional.empty();
         }
-        return !useRepositoryCache(requestContext) ? Optional.empty() :
-                Optional.ofNullable(refresher.getConsumerSupplier()).map(Supplier::get);
+        return Optional.ofNullable(refresher.getConsumerSupplier()).map(Supplier::get);
     }
 
-    private boolean useRepositoryCache(final ConciergeRequestContext requestContext) {
+    private boolean cacheEnabled(final ConciergeRequestContext requestContext) {
         return null != requestContext && !requestContext.isIgnoreCache()
-                && null != cacheConfig && cacheConfig.isEnabled() && null != refresher;
+                && null != cacheConfig && cacheConfig.isEnabled()
+                && null != refresher;
     }
 
-    private boolean match(ConfigDetails configDetails, SearchRequest searchRequest) {
-        final var configKey = configDetails.getConfigKey();
-        final var namespaceMatch = CollectionUtils.isNullOrEmpty(searchRequest.getNamespaces()) ||
-                searchRequest.getNamespaces().contains(configKey.getNamespace());
-        final var configNameMatch = CollectionUtils.isNullOrEmpty(searchRequest.getConfigNames()) ||
-                searchRequest.getConfigNames().contains(configKey.getConfigName());
-        final var configStateMatch = CollectionUtils.isNullOrEmpty(searchRequest.getConfigStates()) ||
-                searchRequest.getConfigStates().contains(configDetails.getConfigState());
-        final var orgMatch = CollectionUtils.isNullOrEmpty(searchRequest.getOrgs()) ||
-                searchRequest.getOrgs().contains(configKey.getOrgId());
-        final var tenantMatch = CollectionUtils.isNullOrEmpty(searchRequest.getTenants()) ||
-                searchRequest.getTenants().contains(configKey.getTenantId());
-        final var configTypeMatch = CollectionUtils.isNullOrEmpty(searchRequest.getConfigTypes()) ||
-                searchRequest.getConfigTypes().contains(configKey.getConfigType());
-        return namespaceMatch && configNameMatch && configStateMatch
-                && orgMatch && tenantMatch && configTypeMatch;
+    private boolean useRepositoryCache(final ConciergeRequestContext requestContext, final String configType) {
+        return null != requestContext && !requestContext.isIgnoreCache()
+                && null != cacheConfig && cacheConfig.isEnabled()
+                && cacheConfig.cachedType(configType)
+                && null != refresher;
     }
 }

--- a/concierge-core/src/test/java/com/grookage/concierge/core/engine/ApproveConfigProcessorTest.java
+++ b/concierge-core/src/test/java/com/grookage/concierge/core/engine/ApproveConfigProcessorTest.java
@@ -43,7 +43,7 @@ class ApproveConfigProcessorTest extends AbstractProcessorTest {
         configDetails.setConfigState(ConfigState.APPROVED);
         Mockito.when(getConciergeRepository().getStoredRecord(configKey))
                 .thenReturn(Optional.of(configDetails));
-        Assertions.assertThrows(ConciergeException.class, () -> processor.process(conciergeContext));
+        processor.process(conciergeContext);
         Mockito.verify(getConciergeRepository(), Mockito.times(0)).update(configDetails);
     }
 

--- a/concierge-core/src/test/java/com/grookage/concierge/core/engine/CreateConfigProcessorTest.java
+++ b/concierge-core/src/test/java/com/grookage/concierge/core/engine/CreateConfigProcessorTest.java
@@ -36,7 +36,9 @@ class CreateConfigProcessorTest extends AbstractProcessorTest {
         Mockito.when(getConciergeRepository().getStoredRecords(Mockito.any()))
                 .thenReturn(List.of(configDetails));
         final var processor = getConciergeProcessor();
-        Assertions.assertThrows(ConciergeException.class, () -> processor.process(conciergeContext));
+        processor.process(conciergeContext);
+        Mockito.verify(getConciergeRepository(), Mockito.times(0))
+                        .create(Mockito.any(ConfigDetails.class));
     }
 
     @Test

--- a/concierge-core/src/test/java/com/grookage/concierge/core/engine/CreateConfigProcessorTest.java
+++ b/concierge-core/src/test/java/com/grookage/concierge/core/engine/CreateConfigProcessorTest.java
@@ -3,11 +3,10 @@ package com.grookage.concierge.core.engine;
 import com.grookage.concierge.core.engine.processors.CreateConfigProcessor;
 import com.grookage.concierge.core.utils.ContextUtils;
 import com.grookage.concierge.models.ResourceHelper;
+import com.grookage.concierge.models.SearchRequest;
 import com.grookage.concierge.models.config.ConfigDetails;
-import com.grookage.concierge.models.exception.ConciergeException;
 import com.grookage.concierge.models.ingestion.ConfigurationRequest;
 import lombok.SneakyThrows;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -33,12 +32,12 @@ class CreateConfigProcessorTest extends AbstractProcessorTest {
                 ConfigDetails.class);
         conciergeContext.addContext(ConfigurationRequest.class.getSimpleName(), createConfigRequest);
         ContextUtils.addConfigUpdaterContext(conciergeContext, getConfigUpdater());
-        Mockito.when(getConciergeRepository().getStoredRecords(Mockito.any()))
+        Mockito.when(getConciergeRepository().getStoredRecords(Mockito.any(SearchRequest.class)))
                 .thenReturn(List.of(configDetails));
         final var processor = getConciergeProcessor();
         processor.process(conciergeContext);
         Mockito.verify(getConciergeRepository(), Mockito.times(0))
-                        .create(Mockito.any(ConfigDetails.class));
+                .create(Mockito.any(ConfigDetails.class));
     }
 
     @Test
@@ -49,7 +48,7 @@ class CreateConfigProcessorTest extends AbstractProcessorTest {
                 ConfigurationRequest.class);
         conciergeContext.addContext(ConfigurationRequest.class.getSimpleName(), createConfigRequest);
         ContextUtils.addConfigUpdaterContext(conciergeContext, getConfigUpdater());
-        Mockito.when(getConciergeRepository().getStoredRecords(Mockito.any()))
+        Mockito.when(getConciergeRepository().getStoredRecords(Mockito.any(SearchRequest.class)))
                 .thenReturn(List.of());
         final var processor = getConciergeProcessor();
         processor.process(conciergeContext);

--- a/concierge-core/src/test/java/com/grookage/concierge/core/services/impl/IngestionServiceImplTest.java
+++ b/concierge-core/src/test/java/com/grookage/concierge/core/services/impl/IngestionServiceImplTest.java
@@ -16,11 +16,7 @@ import lombok.SneakyThrows;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.ArgumentMatchers;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
+import org.mockito.*;
 
 import java.util.Optional;
 

--- a/concierge-dw/pom.xml
+++ b/concierge-dw/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>1.0.6</version>
+        <version>1.0.7</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-dw/src/main/java/com/grookage/conceirge/dwserver/ConciergeBundle.java
+++ b/concierge-dw/src/main/java/com/grookage/conceirge/dwserver/ConciergeBundle.java
@@ -67,7 +67,7 @@ public abstract class ConciergeBundle<T extends Configuration, U extends ConfigU
         return DefaultAppendConfigResolver::new;
     }
 
-    protected ConfigVersionManager getConfigVersionManageR(T configuration) {
+    protected ConfigVersionManager getConfigVersionManager(T configuration) {
         return new DefaultConfigVersionManager();
     }
 
@@ -90,7 +90,7 @@ public abstract class ConciergeBundle<T extends Configuration, U extends ConfigU
         final var configDataValidator = getConfigDataValidator(configuration);
         Preconditions.checkNotNull(configDataValidator, "Config Data Resolver can't be null");
 
-        final var configVersionManager = getConfigVersionManageR(configuration);
+        final var configVersionManager = getConfigVersionManager(configuration);
         Preconditions.checkNotNull(configVersionManager, "Config Version Manager can't be null");
 
         final var cacheConfig = getCacheConfig(configuration);
@@ -120,7 +120,8 @@ public abstract class ConciergeBundle<T extends Configuration, U extends ConfigU
         withHealthChecks(configuration)
                 .forEach(leiaHealthCheck -> environment.healthChecks().register(leiaHealthCheck.getName(), leiaHealthCheck));
         environment.jersey().register(new ConciergeExceptionMapper());
-        environment.jersey().register(new IngestionResource<>(ingestionService, userResolver, permissionResolver, configDataValidator));
+        environment.jersey().register(new IngestionResource<>(ingestionService, userResolver, permissionResolver,
+                configDataValidator, configVersionManager));
         environment.jersey().register(new ConfigResource(configService));
     }
 

--- a/concierge-dw/src/main/java/com/grookage/conceirge/dwserver/resources/ConfigResource.java
+++ b/concierge-dw/src/main/java/com/grookage/conceirge/dwserver/resources/ConfigResource.java
@@ -77,12 +77,14 @@ public class ConfigResource {
     @GET
     @Timed
     @ExceptionMetered
-    @Path("/{referenceId}/summary")
+    @Path("/{configType}/{referenceId}/summary")
     public List<ConfigurationResponse> getConfigDetails(
             @QueryParam("ignoreCache") boolean ignoreCache,
+            @PathParam("configType") @NotEmpty String configType,
             @PathParam("referenceId") @NotEmpty final String referenceId
     ) {
-        final var config = configService.getConfig(toRequestContext(ignoreCache), referenceId).orElse(null);
+        final var config = configService.getConfig(toRequestContext(ignoreCache), configType, referenceId)
+                .orElse(null);
         return getConfigurationResponses(null == config ? List.of() : List.of(config));
     }
 

--- a/concierge-dw/src/main/java/com/grookage/conceirge/dwserver/resources/IngestionResource.java
+++ b/concierge-dw/src/main/java/com/grookage/conceirge/dwserver/resources/IngestionResource.java
@@ -20,6 +20,7 @@ import com.codahale.metrics.annotation.ExceptionMetered;
 import com.codahale.metrics.annotation.Timed;
 import com.grookage.conceirge.dwserver.permissions.PermissionValidator;
 import com.grookage.conceirge.dwserver.resolvers.ConfigUpdaterResolver;
+import com.grookage.concierge.core.engine.resolver.ConfigVersionManager;
 import com.grookage.concierge.core.engine.validator.ConfigDataValidator;
 import com.grookage.concierge.core.services.IngestionService;
 import com.grookage.concierge.models.ConfigUpdater;
@@ -56,6 +57,7 @@ public class IngestionResource<U extends ConfigUpdater> {
     private final Supplier<ConfigUpdaterResolver<U>> updaterResolver;
     private final Supplier<PermissionValidator<U>> permissionValidatorSupplier;
     private final Supplier<ConfigDataValidator> configDataValidatorSupplier;
+    private final ConfigVersionManager versionManager;
 
     @PUT
     @Timed
@@ -66,6 +68,8 @@ public class IngestionResource<U extends ConfigUpdater> {
         final var updater = updaterResolver.get().resolve(headers);
         permissionValidatorSupplier.get().authorize(headers, updater, configurationRequest);
         configDataValidatorSupplier.get().validate(configurationRequest.getConfigKey(), configurationRequest.getData());
+        final var versionId = versionManager.generateConfigVersion(configurationRequest.getConfigKey());
+        configurationRequest.addVersion(versionId);
         return ingestionService.createConfiguration(updater, configurationRequest);
     }
 

--- a/concierge-elastic-dw/pom.xml
+++ b/concierge-elastic-dw/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>1.0.6</version>
+        <version>1.0.7</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-elastic/pom.xml
+++ b/concierge-elastic/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>1.0.6</version>
+        <version>1.0.7</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-elastic/src/main/java/com/grookage/concierge/elastic/repository/ElasticRepository.java
+++ b/concierge-elastic/src/main/java/com/grookage/concierge/elastic/repository/ElasticRepository.java
@@ -20,7 +20,10 @@ import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.Refresh;
 import co.elastic.clients.elasticsearch._types.Time;
-import co.elastic.clients.elasticsearch._types.query_dsl.*;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.MatchAllQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.TermsQuery;
 import co.elastic.clients.elasticsearch.core.*;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.elasticsearch.indices.CreateIndexRequest;
@@ -30,6 +33,7 @@ import com.google.common.base.Preconditions;
 import com.grookage.concierge.elastic.client.ElasticClientManager;
 import com.grookage.concierge.elastic.config.ElasticConfig;
 import com.grookage.concierge.elastic.storage.StoredElasticRecord;
+import com.grookage.concierge.models.PageWindow;
 import com.grookage.concierge.models.config.ConfigDetails;
 import com.grookage.concierge.models.config.ConfigState;
 import com.grookage.concierge.repository.ConciergeRepository;
@@ -115,11 +119,13 @@ public class ElasticRepository implements ConciergeRepository {
 
     @SneakyThrows
     private List<ConfigDetails> queryDetails(final Query searchQuery,
+                                             final PageWindow pageWindow,
                                              final Predicate<Hit<StoredElasticRecord>> searchPredicate) {
         final var searchResponse = client.search(SearchRequest.of(
                         s -> s.query(searchQuery)
                                 .requestCache(true)
                                 .index(List.of(CONFIG_INDEX))
+                                .from(pageWindow.offset())
                                 .size(elasticConfig.getMaxResultSize()) //If you have more than 10K schemas, this will hold you up!
                                 .timeout(elasticConfig.getTimeout())),
                 StoredElasticRecord.class
@@ -148,7 +154,7 @@ public class ElasticRepository implements ConciergeRepository {
                         _toQuery();
         final var searchQuery = BoolQuery.of(q -> q.must(List.of(orgQuery, namespaceQuery, tenantQuery,
                 configQuery, configTypeQuery, configStateQuery)))._toQuery();
-        return queryDetails(searchQuery, storedElasticRecordHit -> true);
+        return queryDetails(searchQuery, searchRequest.getPageWindow(), storedElasticRecordHit -> true);
     }
 
     @Override
@@ -178,19 +184,11 @@ public class ElasticRepository implements ConciergeRepository {
 
     @Override
     @SneakyThrows
-    public Optional<ConfigDetails> getStoredRecord(String referenceId) {
+    public Optional<ConfigDetails> getStoredRecord(String configType, String referenceId) {
         final var getResponse = client.get(GetRequest.of(request ->
                         request.index(CONFIG_INDEX).id(referenceId)),
                 StoredElasticRecord.class);
         return Optional.ofNullable(getResponse.source()).map(this::toConfigDetails);
-    }
-
-    @Override
-    @SneakyThrows
-    public List<ConfigDetails> getStoredRecords() {
-        final var query = MatchAllQuery.of(q -> q)._toQuery();
-        final var searchQuery = BoolQuery.of(q -> q.must(List.of(query)))._toQuery();
-        return queryDetails(searchQuery, storedElasticRecordHit -> true);
     }
 
     @Override

--- a/concierge-models/pom.xml
+++ b/concierge-models/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>1.0.6</version>
+        <version>1.0.7</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-models/src/main/java/com/grookage/concierge/models/PageWindow.java
+++ b/concierge-models/src/main/java/com/grookage/concierge/models/PageWindow.java
@@ -1,0 +1,28 @@
+package com.grookage.concierge.models;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PageWindow {
+    @Builder.Default
+    @Min(0)
+    private int page = 0;
+    @Builder.Default
+    @Max(10000)
+    private int pageSize = 100;
+
+    public int offset() {
+        return page * pageSize;
+    }
+}

--- a/concierge-models/src/main/java/com/grookage/concierge/models/SearchRequest.java
+++ b/concierge-models/src/main/java/com/grookage/concierge/models/SearchRequest.java
@@ -28,7 +28,7 @@ import java.util.Set;
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
-@Builder
+@Builder(toBuilder = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class SearchRequest {
     @Builder.Default
@@ -43,4 +43,6 @@ public class SearchRequest {
     private Set<ConfigState> configStates = Set.of();
     @Builder.Default
     private Set<String> configTypes = Set.of();
+    @Builder.Default
+    private PageWindow pageWindow = new PageWindow();
 }

--- a/concierge-models/src/main/java/com/grookage/concierge/models/config/ConfigKey.java
+++ b/concierge-models/src/main/java/com/grookage/concierge/models/config/ConfigKey.java
@@ -26,7 +26,6 @@ public class ConfigKey {
     String tenantId;
     @NotBlank
     String configName;
-    @NotBlank
     String version;
     @NotBlank
     String configType;

--- a/concierge-models/src/main/java/com/grookage/concierge/models/ingestion/ConfigurationRequest.java
+++ b/concierge-models/src/main/java/com/grookage/concierge/models/ingestion/ConfigurationRequest.java
@@ -21,4 +21,8 @@ public class ConfigurationRequest {
     @NotNull
     ConfigKey configKey;
     String message;
+
+    public void addVersion(final String version) {
+        this.configKey.setVersion(version);
+    }
 }

--- a/concierge-parent/pom.xml
+++ b/concierge-parent/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-bom</artifactId>
-        <version>1.0.6</version>
+        <version>1.0.7</version>
         <relativePath>../concierge-bom</relativePath>
     </parent>
 

--- a/concierge-repository/pom.xml
+++ b/concierge-repository/pom.xml
@@ -56,11 +56,6 @@
             <version>4.1.0</version>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
-
-    <properties>
-        <maven.deploy.skip>true</maven.deploy.skip>
-    </properties>
 
 </project>

--- a/concierge-repository/pom.xml
+++ b/concierge-repository/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>1.0.6</version>
+        <version>1.0.7</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/concierge-repository/src/main/java/com/grookage/concierge/repository/ConciergeRepository.java
+++ b/concierge-repository/src/main/java/com/grookage/concierge/repository/ConciergeRepository.java
@@ -6,6 +6,7 @@ import com.grookage.concierge.models.config.ConfigKey;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface ConciergeRepository {
 
@@ -13,13 +14,18 @@ public interface ConciergeRepository {
 
     void update(ConfigDetails configDetails);
 
-    Optional<ConfigDetails> getStoredRecord(final String referenceId);
+    Optional<ConfigDetails> getStoredRecord(final String configType, final String referenceId);
 
     default Optional<ConfigDetails> getStoredRecord(final ConfigKey configKey) {
-        return getStoredRecord(configKey.getReferenceId());
+        return getStoredRecord(configKey.getConfigType(), configKey.getReferenceId());
     }
 
-    List<ConfigDetails> getStoredRecords();
+    default List<ConfigDetails> getStoredRecords(final String configType) {
+        final var searchRequest = SearchRequest.builder()
+                .configTypes(Set.of(configType))
+                .build();
+        return getStoredRecords(searchRequest);
+    }
 
     List<ConfigDetails> getStoredRecords(SearchRequest searchRequest);
 

--- a/concierge-server-example/pom.xml
+++ b/concierge-server-example/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.grookage.concierge</groupId>
         <artifactId>concierge-parent</artifactId>
-        <version>1.0.6</version>
+        <version>1.0.7</version>
         <relativePath>../concierge-parent</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.grookage.concierge</groupId>
     <artifactId>concierge</artifactId>
-    <version>1.0.6</version>
+    <version>1.0.7</version>
     <packaging>pom</packaging>
 
     <name>Concierge</name>


### PR DESCRIPTION
**Features**
- Added pagination support via `PageWindow` in `SearchRequest` with configurable `page` and `pageSize`
- Pagination applied across all repository implementations (Aerospike, Elasticsearch) and in-memory cache

**Improvements**
- `ConfigServiceImpl.getConfigs` now fetches cached and non-cached config types in parallel using `CompletableFuture`, improving performance for mixed queries
- `SearchRequest` now supports `toBuilder()` for easier request modification
- Code cleanup: Replaced imperative patterns with streams and `Optional` chaining in `ConfigRegistry`
    - `computeIfAbsent` for nested map operations
    - Stream-based filtering in `getMatchingConfigs`
    - `Optional.ofNullable().map()` in `getConfigDetails`
- `CacheConfig.cachedType` simplified to use `equalsIgnoreCase` for case-insensitive matching